### PR TITLE
Bugfix HTML-Tag language attribute

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="js" lang="<?php echo $Site->language() ?>">
+<html class="js" lang="<?php echo substr($Site->language(),0,2); ?>">
 
 	<head profile="http://gmpg.org/xfn/11">
 		<?php include(THEME_DIR_PHP.'head.php') ?>


### PR DESCRIPTION
For using css hyphens correct, the language needs to be declared according to the w3 standard. As you can see [here](https://www.w3.org/International/questions/qa-html-language-declarations.en#attributes) the attribute "language" has to be just a two letter value. By returning just the first to signs the bug is fixed.